### PR TITLE
Fixing csv reading

### DIFF
--- a/src/test/java/org/mskcc/cellranger/controller/CellRangerControllerTest.java
+++ b/src/test/java/org/mskcc/cellranger/controller/CellRangerControllerTest.java
@@ -194,8 +194,9 @@ public class CellRangerControllerTest {
     public void saveCellRangerSampleTest_fail() {
         CellRangerType[] types = getCellRangerTypes();
         for(CellRangerType type : types){
+            String[] params = new String[0];
             try {
-                String[] params = new String[]{type.toString(), SAMPLE, PROJECT, RUN};
+                params = new String[]{type.toString(), SAMPLE, PROJECT, RUN};
                 String temp;
                 for(int i = 0; i<params.length; i++){
                     temp = params[i];
@@ -208,6 +209,8 @@ public class CellRangerControllerTest {
                 }
             } catch(IOException e){
                 log.error(String.format("Failed to test %s. Error: %s", type, e.getMessage()));
+            } catch(NullPointerException e){
+                assertEquals("Null Pointer only valid if type is invalid", params[0], "INVALID_PARAM");
             }
         }
     }

--- a/src/test/java/org/mskcc/utils/ParserUtilTest.java
+++ b/src/test/java/org/mskcc/utils/ParserUtilTest.java
@@ -55,4 +55,16 @@ public class ParserUtilTest {
 
         Assert.assertEquals(parsedLine.size(), expected.length);
     }
+
+    @Test
+    public void parseCellRangerCsvLineTest_edge2() {
+        final String csvLine = "\"2,166\",\"49,188\",218,\"106,542,626\",81.5%,95.0%,95.8%,93.7%,88.4%,95.3%,75.9%,60.8%,15.5%,3.8%,30.5%,28.9%,7.2%,54.0%,\"17,651\",369";
+        String[] expected = { "2166", "49188", "218", "106542626", "0.815", "0.95", "0.958", "0.937", "0.884", "0.953", "0.759", "0.608", "0.155", "0.038", "0.305", "0.289", "0.072", "0.54", "17651", "369" };
+        List<String> parsedLine = ParserUtil.parseCellRangerCsvLine(csvLine);
+        for(int i = 0; i<parsedLine.size(); i++){
+            Assert.assertEquals(expected[i], parsedLine.get(i));
+        }
+
+        Assert.assertEquals(parsedLine.size(), expected.length);
+    }
 }


### PR DESCRIPTION
BUG: Call to save CSV file was failing w/ error `"Failed to read file for w/ name 'Sample_1026a_VDJ_IGO_10243_K_1' (Project: 'Project_10243_K', Run: 'DIANA_0213_10XGenomics', Type: 'count')"`
* Certain Fields in the csv file need a mapping to their sql column. There was a missing mapping for "Q30 Bases in RNA Read 2", which is not present in all metrics reported (usually should just be present for vdj)

FIX: Handle missing mapping and add logging that reports this missing mapping. [Run-QC Site](https://igo.mskcc.org/run-qc/projects/10243_K)