### PR TITLE
Not allowing wildcard at end of project dir

### DIFF
--- a/src/main/java/org/mskcc/cellranger/controller/CellRangerController.java
+++ b/src/main/java/org/mskcc/cellranger/controller/CellRangerController.java
@@ -472,8 +472,8 @@ public class CellRangerController {
 
             return cellRangerOutputPath;
         } catch(FileNotFoundException e) {
-            log.error("Could not find CellRangerOutputPath w/ RUN=%s SAMPLE=%s PROJECT=%s TYPE=%s",
-                    run, sample, project, type);
+            log.error(String.format("Could not find CellRangerOutputPath w/ RUN=%s SAMPLE=%s PROJECT=%s TYPE=%s",
+                    run, sample, project, type));
         }
         return "";
     }

--- a/src/main/java/org/mskcc/cellranger/controller/CellRangerController.java
+++ b/src/main/java/org/mskcc/cellranger/controller/CellRangerController.java
@@ -456,7 +456,7 @@ public class CellRangerController {
      */
     private String getCellRangerOutputPath(String run, String sample, String project, String type, String path) {
         String runRegex = String.format(".*%s.*", run);
-        String prjRegex = String.format(".*%s.*", project);
+        String prjRegex = String.format(".*%s", project);
         String smpRegex = String.format(".*%s.*%s", sample, type);
 
         Path cellRangerPath = Paths.get(CELL_RANGER_DIR);


### PR DESCRIPTION
**Bug**: Couldn't find only ONE directory for a parent request that had a child request w/ cellranger data. i.e. searching for project 10000's directory yielded ambiguous results of `10000` & `10000_B`

**LOG**
```
2021-07-29 13:40:46 ERROR o.m.c.c.CellRangerController - Ambiguous matching of .*10000.* in /igo/stats/CELLRANGER/RUN
```

**DIRECTORY**
```
$ ls -ltr /igo/stats/CELLRANGER/RUN/
total 0
drwxr-xr-x 2 res_igo_seq seqdatagrp 0 Jul 22 11:36 10000
drwxr-xr-x 2 res_igo_seq seqdatagrp 0 Jul 23 08:36 10000_B
```